### PR TITLE
Fix collapse detection to use uint8 observations

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -172,7 +172,7 @@ class PolicyCollapseCallback(BaseCallback):
         # This tests if the policy has collapsed to always choosing one action
         for _ in range(self.n_eval_samples):
             # Create random observations (batch of n_envs observations)
-            random_obs = np.random.rand(n_envs, *obs_shape).astype(np.float32)
+            random_obs = np.random.randint(0, 256, size=(n_envs, *obs_shape), dtype=np.uint8)
 
             # Get action from policy
             action, _ = self.model.predict(random_obs, deterministic=False)


### PR DESCRIPTION
## Summary
- Change random observation generation in `PolicyCollapseCallback` from `float32` in `[0,1]` to `uint8` in `[0,255]`
- Training uses uint8 observations (SB3 normalizes on-the-fly), so collapse detection should match
- Prevents testing the policy on out-of-distribution inputs

## Test plan
- [ ] Verify `PolicyCollapseCallback` runs without errors during training
- [ ] Check that collapse detection correctly identifies a known-collapsed model

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)