### PR TITLE
Remove dead ent_coef_schedule function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -69,18 +69,6 @@ def linear_schedule(initial_value: float):
     return func
 
 
-def ent_coef_schedule(initial_value: float, final_value: float = 0.01):
-    """
-    Linear entropy coefficient schedule.
-    Decays from initial_value to final_value over training.
-    """
-
-    def func(progress_remaining: float) -> float:
-        return final_value + (initial_value - final_value) * progress_remaining
-
-    return func
-
-
 def make_env(
     env_id,
     render_mode=None,


### PR DESCRIPTION
## Summary
- Delete unused `ent_coef_schedule()` from `utils.py`
- SB3 doesn't support schedule functions for `ent_coef` (only `learning_rate`), so this was never callable
- Entropy decay is handled by `EntropyDecayCallback` instead

## Test plan
- [ ] Grep codebase to confirm no references to `ent_coef_schedule`
- [ ] Verify training still starts and runs normally

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)