### PR TITLE
Use deque for rolling window in ProgressTrackingCallback

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -4,6 +4,7 @@ Custom callbacks for PPO training.
 
 import os
 import glob
+from collections import deque
 from typing import Optional
 
 import numpy as np
@@ -301,11 +302,11 @@ class ProgressTrackingCallback(BaseCallback):
 
         # Rolling window storage (last 100 episodes)
         self.max_window_size = 100
-        self.episode_max_x_pos: list = []
-        self.episode_flag_get: list = []
-        self.episode_lengths: list = []
-        self.episode_rewards: list = []
-        self.episode_reward_per_step: list = []
+        self.episode_max_x_pos: deque = deque(maxlen=self.max_window_size)
+        self.episode_flag_get: deque = deque(maxlen=self.max_window_size)
+        self.episode_lengths: deque = deque(maxlen=self.max_window_size)
+        self.episode_rewards: deque = deque(maxlen=self.max_window_size)
+        self.episode_reward_per_step: deque = deque(maxlen=self.max_window_size)
 
         # Track current episode per environment (initialized on first step)
         self.current_episode_max_x: Optional[np.ndarray] = None
@@ -389,14 +390,6 @@ class ProgressTrackingCallback(BaseCallback):
                     self.episode_lengths.append(ep_len)
                     self.episode_rewards.append(ep_reward)
                     self.episode_reward_per_step.append(reward_per_step)
-
-                    # Keep only last 100 episodes
-                    if len(self.episode_max_x_pos) > self.max_window_size:
-                        self.episode_max_x_pos.pop(0)
-                        self.episode_flag_get.pop(0)
-                        self.episode_lengths.pop(0)
-                        self.episode_rewards.pop(0)
-                        self.episode_reward_per_step.pop(0)
 
                     # Reset tracking for next episode
                     self.current_episode_max_x[i] = 0.0


### PR DESCRIPTION
## Summary
- Replace `list` + manual `pop(0)` with `collections.deque(maxlen=100)` for the 5 rolling-window lists
- `list.pop(0)` is O(n) per call; `deque` handles eviction automatically in O(1)
- Remove the now-unnecessary manual size-check block

## Test plan
- [ ] Verify `ProgressTrackingCallback` still logs correct rolling-window stats during training
- [ ] Confirm deque maxlen matches `self.max_window_size` (100)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)