### PR TITLE
Fix outdated docstring obs shape in MarioImpalaExtractor

### DIFF
--- a/networks.py
+++ b/networks.py
@@ -51,7 +51,7 @@ class MarioImpalaExtractor(BaseFeaturesExtractor):
     """
     IMPALA-style CNN feature extractor for Mario training.
 
-    Accepts Box observation space (C, H, W) - e.g., (4, 160, 160) for stacked grayscale frames.
+    Accepts Box observation space (C, H, W) - e.g., (12, 120, 128) for 4 stacked RGB frames.
 
     Architecture:
         - 3 IMPALA stages with depths [16, 32, 32]


### PR DESCRIPTION
## Summary
- Update `MarioImpalaExtractor` docstring from `(4, 160, 160) for stacked grayscale frames` to `(12, 120, 128) for 4 stacked RGB frames`
- The training config uses RGB (3 channels) at 128x120 with 4 stacked frames, giving shape (12, 120, 128)

## Test plan
- [ ] Confirm docstring matches actual observation shape from `make_env()` in `utils.py`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)