### PR TITLE
Fix reward wrapper state leak on truncation

### DIFF
--- a/wrappers.py
+++ b/wrappers.py
@@ -310,6 +310,15 @@ class CustomRewardWrapper(gym.Wrapper):
         self._prev_score = score
         self._prev_coins = coins
 
+        # Reset state for next episode (gym auto-resets without calling wrapper.reset())
+        if done or truncated:
+            self._prev_x_pos = 0
+            self._max_x_pos = 0
+            self._prev_time = 400
+            self._prev_score = 0
+            self._prev_coins = 0
+            self._stuck_counter = 0
+
         return obs, total_reward, done, truncated, info
 
 


### PR DESCRIPTION
## Summary
- Reset `CustomRewardWrapper` tracking state (`_max_x_pos`, `_prev_x_pos`, etc.) at the end of `step()` when `done or truncated`
- Fixes stale state leak when gym auto-resets after truncation without calling `wrapper.reset()`
- Prevents forward-progress rewards from being suppressed in the new episode

## Test plan
- [ ] Verify reward wrapper resets state correctly after truncation
- [ ] Confirm forward-progress rewards work properly in episodes following a truncation

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)