### PR TITLE
Replace bare except with specific exceptions

### DIFF
--- a/diagnose_policy.py
+++ b/diagnose_policy.py
@@ -142,7 +142,7 @@ def find_healthy_checkpoint(model_dir, max_checkpoints=10, env_id="1-1"):
         name = os.path.basename(path)
         try:
             return int(name.split("_")[-2])
-        except:
+        except (ValueError, IndexError):
             return 0
 
     checkpoints = sorted(checkpoints, key=get_steps)


### PR DESCRIPTION
## Summary
- Change `except:` to `except (ValueError, IndexError):` in checkpoint filename parsing
- Prevents catching `KeyboardInterrupt` and `SystemExit`, allowing Ctrl+C to work during checkpoint scanning

## Test plan
- [ ] Verify checkpoint scanning still works with valid and invalid filenames
- [ ] Verify Ctrl+C properly interrupts the script during scanning

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)