### PR TITLE
Guard save_freq against zero when checkpoint_freq < n_envs

### DIFF
--- a/train_ppo.py
+++ b/train_ppo.py
@@ -202,7 +202,7 @@ def train(
 
     # Setup callbacks
     checkpoint_callback = CheckpointCallback(
-        save_freq=checkpoint_freq // n_envs,  # Divide by n_envs for SubprocVecEnv
+        save_freq=max(1, checkpoint_freq // n_envs),  # Divide by n_envs for SubprocVecEnv
         save_path=checkpoint_dir,
         name_prefix="checkpoint",
         save_replay_buffer=False,


### PR DESCRIPTION
## Summary
- Wrap `checkpoint_freq // n_envs` with `max(1, ...)` to prevent `save_freq=0` when `checkpoint_freq < n_envs`, which would cause SB3's `CheckpointCallback` to error.

## Test plan
- [ ] Verify the fix by inspecting `train_ppo.py:205`
- [ ] Confirm training starts without error when `checkpoint_freq < n_envs`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when checkpoint_freq < n_envs by guarding CheckpointCallback save_freq with max(1, checkpoint_freq // n_envs). Ensures PPO training runs and checkpoints reliably even with small checkpoint intervals.

<sup>Written for commit 07d34138e3437e269b8aa0fc817c47476a6f05b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

