### PR TITLE
Copy observations in FrameStack to prevent aliased array mutation

### DIFF
--- a/wrappers.py
+++ b/wrappers.py
@@ -123,7 +123,7 @@ class FrameStack(gym.Wrapper):
             info = {}
 
         # Initialize frame stack with copies of first observation
-        self.frames = [obs] * self.n_frames
+        self.frames = [obs.copy() for _ in range(self.n_frames)]
         stacked = np.concatenate(self.frames, axis=-1)
         return stacked, info
 
@@ -132,7 +132,7 @@ class FrameStack(gym.Wrapper):
 
         # Update frame stack
         self.frames.pop(0)
-        self.frames.append(obs)
+        self.frames.append(obs.copy())
         stacked = np.concatenate(self.frames, axis=-1)
 
         return stacked, reward, done, truncated, info


### PR DESCRIPTION
## Summary
- `reset()` used `[obs] * n_frames` which aliases the same array object for all frames — now uses `[obs.copy() for _ in range(n_frames)]`
- `step()` appended `obs` without copying — now uses `obs.copy()`
- If the underlying env reuses its observation buffer, the old code caused all stacked frames to point to the same memory, breaking temporal frame stacking

## Test plan
- [ ] Verify `reset()` returns a stack of identical (but independent) frames
- [ ] Verify `step()` produces correctly shifted frame stacks across consecutive steps

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copy observations in FrameStack on reset and step to prevent aliased array mutation. Restores correct temporal stacking when the env reuses its observation buffer.

- **Bug Fixes**
  - In reset, replace [obs] * n_frames with [obs.copy() for _ in range(n_frames)].
  - In step, append obs.copy() instead of obs.

<sup>Written for commit 236d1b65825666692f7d337b8ce88016e28e6671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

