### PR TITLE
Scale callback check_freq by n_envs for correct timestep intervals

### DIFF
--- a/train_ppo.py
+++ b/train_ppo.py
@@ -221,7 +221,7 @@ def train(
 
     # Policy collapse detection and auto-recovery callback
     collapse_callback = PolicyCollapseCallback(
-        check_freq=50_000,  # Check every 50k steps
+        check_freq=max(1, 2_400_000 // n_envs),  # Check every ~2.4M timesteps
         dominant_action_threshold=0.85,  # Trigger if any action > 85%
         entropy_threshold=0.3,  # Trigger if entropy < 0.3
         checkpoint_dir=checkpoint_dir,
@@ -232,7 +232,7 @@ def train(
 
     # Episode-level progress tracking callback
     progress_callback = ProgressTrackingCallback(
-        check_freq=10_000,  # Log every 10k steps
+        check_freq=max(1, 480_000 // n_envs),  # Log every ~480k timesteps
         verbose=1,
     )
 


### PR DESCRIPTION
## Summary
- `PolicyCollapseCallback` and `ProgressTrackingCallback` used raw `check_freq` values without dividing by `n_envs`, making their actual firing intervals `check_freq * n_envs` timesteps (48x what comments claimed)
- Apply the same `// n_envs` pattern already used by `CheckpointCallback` and `EvalCallback`, with scaled-up raw values to preserve the current effective intervals

## Test plan
- [ ] Verify with `n_envs=48`: `2_400_000 // 48 = 50_000` and `480_000 // 48 = 10_000` (same n_calls as before)
- [ ] Confirm callbacks fire at the same rate during training

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaled check_freq in PolicyCollapseCallback and ProgressTrackingCallback by n_envs so they fire at the correct timestep intervals, consistent with Checkpoint/Eval callbacks. Keeps current cadence with max(1, 2,400,000 // n_envs) and max(1, 480,000 // n_envs) (e.g., n_envs=48 → 50k and 10k); closes #25.

<sup>Written for commit b6be19ae6c3275ac7d6a7b798cbf7e4cd464db4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

