### PR TITLE
Refresh LR schedule after overriding learning_rate on resume

### DIFF
--- a/train_ppo.py
+++ b/train_ppo.py
@@ -164,6 +164,7 @@ def train(
         )
         # Update hyperparameters for resumed training
         model.learning_rate = lr
+        model._setup_lr_schedule()  # Rebuild schedule so _update_learning_rate() uses the new LR
         model.ent_coef = (
             ent_coef  # Initial value, will be decayed by EntropyDecayCallback
         )


### PR DESCRIPTION
## Summary
- When resuming training with a new `--lr`, SB3's internal `lr_schedule` was not rebuilt, causing the new learning rate to be silently ignored
- Added `model._setup_lr_schedule()` call after setting `model.learning_rate` to rebuild the schedule from the new value

Closes #27

## Test plan
- [ ] Resume training with a different `--lr` and verify in TensorBoard that the optimizer uses the new learning rate
- [ ] Verify fresh training (no resume) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuild the learning rate schedule when resuming training with a new --lr so the updated value takes effect. After setting model.learning_rate, we now call model._setup_lr_schedule() to refresh SB3’s internal lr_schedule.

<sup>Written for commit da8977211b3c8471fce21bdf3fbc49c8c1e75f9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

