### PR TITLE
Add future annotations import to support Python <3.9

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,8 @@
 Utility functions for Mario PPO training.
 """
 
+from __future__ import annotations
+
 import numpy as np
 
 


### PR DESCRIPTION
## Summary
- `utils.py:147` uses `list[str]` as a return annotation, which raises `TypeError` at import time on Python 3.8
- Added `from __future__ import annotations` (PEP 563) to defer annotation evaluation

Closes #29

## Test plan
- [ ] Verify `import utils` succeeds on Python 3.8
- [ ] Verify no runtime behavior changes on Python 3.9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix import error on Python 3.8 by adding from __future__ import annotations to utils.py. This defers evaluation of list[str] in normalize_env_ids and keeps behavior unchanged on Python 3.9+."""

<sup>Written for commit 191eb9f61c8a605ff6d8625fb75b82788e57fefc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

