### PR TITLE
Exit non-zero when callback tests fail

### DIFF
--- a/test_callbacks.py
+++ b/test_callbacks.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 """Quick test to verify callbacks are working."""
 
+import sys
+
 from callbacks import ProgressTrackingCallback, PolicyCollapseCallback
+
+failures = 0
 
 print("=" * 60)
 print("CALLBACK VERIFICATION TEST")
@@ -16,6 +20,7 @@ try:
     print(f"  - Has _on_step method: {hasattr(ptc, '_on_step')}")
 except Exception as e:
     print(f"[FAIL] FAILED to instantiate ProgressTrackingCallback: {e}")
+    failures += 1
 
 print()
 
@@ -36,8 +41,14 @@ try:
     print(f"  - Has _on_step method: {hasattr(pcc, '_on_step')}")
 except Exception as e:
     print(f"[FAIL] FAILED to instantiate PolicyCollapseCallback: {e}")
+    failures += 1
 
 print()
 print("=" * 60)
-print("[PASS] ALL CALLBACK TESTS PASSED")
-print("=" * 60)
+if failures:
+    print(f"[FAIL] {failures} CALLBACK TEST(S) FAILED")
+    print("=" * 60)
+    sys.exit(1)
+else:
+    print("[PASS] ALL CALLBACK TESTS PASSED")
+    print("=" * 60)


### PR DESCRIPTION
## Summary
- `test_callbacks.py` unconditionally printed `ALL CALLBACK TESTS PASSED` and exited 0, even when exceptions were caught in the test blocks
- Added a `failures` counter incremented in each `except` block, and `sys.exit(1)` at the end when any test failed

Closes #31

## Test plan
- [ ] Run `python test_callbacks.py` normally — should print PASS and exit 0
- [ ] Temporarily break a callback import and run again — should print FAIL and exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure callback test script exits non-zero when failures occur, so CI correctly flags broken callbacks. Previously it always printed PASS and exited 0 even on errors.

- **Bug Fixes**
  - Count failures in each except block.
  - Exit with code 1 when any test fails; keep PASS output and exit 0 otherwise.

<sup>Written for commit 5a65ea97d4b49f73b7e44d508fe7fd88d1612283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

