### PR TITLE
Fix stderr wrapper to delegate missing attributes to underlying stream

### DIFF
--- a/suppress_warnings.py
+++ b/suppress_warnings.py
@@ -2,19 +2,17 @@
 Suppress noisy gym/numpy deprecation warnings.
 Import this module before any gym imports.
 """
-import warnings
 import sys
+import warnings
 
 
 class _SuppressGymWarning:
     def __init__(self, stream):
-        self.stream = stream
-    
+        self._stream = stream
+
     def write(self, msg):
-        # Skip empty or whitespace-only messages
         if not msg or msg.isspace():
             return
-        # Skip known warning patterns
         suppress = [
             'Gym has been unmaintained',
             'bool8',
@@ -22,10 +20,13 @@ class _SuppressGymWarning:
             'UserWarning',
         ]
         if not any(s in msg for s in suppress):
-            self.stream.write(msg)
-    
+            self._stream.write(msg)
+
     def flush(self):
-        self.stream.flush()
+        self._stream.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
 
 
 sys.stderr = _SuppressGymWarning(sys.stderr)


### PR DESCRIPTION
## Summary

The `_SuppressGymWarning` stderr wrapper was missing `isatty`/`fileno`/`encoding` attributes, causing `AttributeError` in libraries that inspect `sys.stderr`.

**Minimal fix — two changes:**
- Add `__getattr__` to delegate any unhandled attribute access to the real stream
- Rename `self.stream` → `self._stream` to prevent `__getattr__` from intercepting internal attribute access

The original suppression logic (string matching + broad `warnings.filterwarnings`) is kept as-is — it works reliably across all 48 SubprocVecEnv workers.

## Test plan
- [ ] Run training with 48 envs — no gym/bool warnings, no empty lines in stderr
- [ ] Verify `sys.stderr.isatty()` and `sys.stderr.fileno()` work without `AttributeError`

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)